### PR TITLE
Feature - Adding more IP ranges to block by default and a new parameter to deny in corefile

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,11 +10,38 @@ With `stopdnsrebind` enabled, users are able to block addresses from upstream na
 
 The import order of this plugin matters, it is possible that it will not work depending on the import order
 
+# 🌐 Default Blocking Rules
+
+### 🔒 Loopback Addresses
+- **`127.0.0.1/8`**
+
+### 🔒 Private Addresses
+- **`10.0.0.0/8`**
+- **`172.16.0.0/12`**
+- **`192.168.0.0/16`**
+
+### 🔒 Link Local Addresses
+- **`169.254.0.0/16`**
+
+### 🔒 Unspecified
+- **`0.0.0.0`**
+
+### 🔒 Interface Local Multicast
+- **`224.0.0.0/24`**
+
+### 🔒 DenyList
+- Add your entries in the plugin configuration.
+
+---
+
+Keeping the network secure! 🔐
+
 ## Syntax
 
 ```
 stopdnsrebind [ZONES...] {
     allow [ZONES...]
+    deny [IPNet]
 }
 ```
 
@@ -28,6 +55,7 @@ To demonstrate the usage of plugin stopdnsrebind, here we provide some typical e
 . {
     stopdnsrebind {
         allow internal.example.org
+        deny 192.0.2.1/24
     }
 }
 ~~~

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# stopdnsrebind
+# coredns-rebind-protection
 
 ## Name
 
@@ -7,6 +7,8 @@
 ## Description
 
 With `stopdnsrebind` enabled, users are able to block addresses from upstream nameservers which are in the private ranges.
+
+The import order of this plugin matters, it is possible that it will not work depending on the import order
 
 ## Syntax
 

--- a/setup_test.go
+++ b/setup_test.go
@@ -41,6 +41,27 @@ func Test_setup(t *testing.T) {
 			}`,
 			true,
 		},
+		{
+			"deny a valid ipNet",
+			`stopdnsrebind {
+				deny 192.0.2.1/24
+			}`,
+			false,
+		},
+		{
+			"deny multiple ipNet",
+			`stopdnsrebind {
+				deny 192.0.2.1/24 127.0.0.1/8
+			}`,
+			false,
+		},
+		{
+			"deny invalid ipNet",
+			`stopdnsrebind {
+				deny 192.0.2.1
+			}`,
+			true,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
Adding new parameter to allow hosts to be blocked from the configuration file -> Deny

Adding more hosts to block by default:
- 224.0.0.0/24
- 192.168.0.0/16
- 172.16.0.0/12

Improving tests and documentation too