### PR TITLE
Remove README emojis and bump Go toolchain to 1.26.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,31 +10,31 @@ With `stopdnsrebind` enabled, users are able to block addresses from upstream na
 
 The import order of this plugin matters, it is possible that it will not work depending on the import order
 
-# 🌐 Default Blocking Rules
+# Default Blocking Rules
 
-### 🔒 Loopback Addresses
+### Loopback Addresses
 - **`127.0.0.1/8`**
 
-### 🔒 Private Addresses
+### Private Addresses
 - **`10.0.0.0/8`**
 - **`172.16.0.0/12`**
 - **`192.168.0.0/16`**
 
-### 🔒 Link Local Addresses
+### Link Local Addresses
 - **`169.254.0.0/16`**
 
-### 🔒 Unspecified
+### Unspecified
 - **`0.0.0.0`**
 
-### 🔒 Interface Local Multicast
+### Interface Local Multicast
 - **`224.0.0.0/24`**
 
-### 🔒 DenyList
+### DenyList
 - Add your entries in the plugin configuration.
 
 ---
 
-Keeping the network secure! 🔐
+Keeping the network secure!
 
 ## Syntax
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/4390c336/stopdnsrebind
 
-go 1.25.0
+go 1.26.2
 
 require (
 	github.com/coredns/caddy v1.1.4


### PR DESCRIPTION
### Motivation
- Remove emoji characters from documentation for cleaner, plain-text README and update the project to the latest stable Go toolchain to ensure compatibility with newer modules and local tooling.

### Description
- Removed emoji characters from `README.md` headings and footer and updated the Go toolchain version in `go.mod` to `go 1.26.2`, then ran `go mod tidy` to refresh module metadata.

### Testing
- Ran `go test ./...` and all tests passed (package tests reported `ok`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e1f09d688c832b964fd3ed236abe38)